### PR TITLE
Activate Travis CI + Slack Notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: java
+jdk:
+- openjdk7
+notifications:
+  slack:
+    secure: hC7ogO0nNSGIuOIqdCVPe8Z4rWjEpeC+szdrQwzjRn+nwDfXxygnOd0iBehL+MV6wzTJ7rkJ3OmkOeOwvreCR+8Kw9WnCNJupwtgtkcGGd8GEFLsHpVlRvPybEelWY3hfQwoaJhrONNaei0AKOu4deWgQ9g4zq40Ha5F7VyyCL4=


### PR DESCRIPTION
Додано .travis.yml для активізації travis CI . Відправляє повідомленя після кожного запуску до https://e-government-ua.slack.com/messages/deploy/team/

Див. також https://travis-ci.org/e-government-ua/i/builds