### PR TITLE
Fixed error on getting cities for non-existing regions

### DIFF
--- a/central-js/server/api/places/index.controller.js
+++ b/central-js/server/api/places/index.controller.js
@@ -82,7 +82,7 @@ function findCities(region, search) {
 	
 	var oRegion = findRegion(region);
 	if(oRegion == null) {
-		return null;
+		return [];
 	}
 	
 	return (search == null) ?


### PR DESCRIPTION
Currently, the request `GET https://e-gov.org.ua/api/places/region/300/cities` returns an error: 

    TypeError: Cannot read property 'length' of null
       at Object.module.exports.getCities (/sybase/central-js/server/api/places/index.controller.js:149:27)
       at /sybase/central-js/server/api/places/index.js:46:21
       at Layer.handle [as handle_request] (/sybase/central-js/node_modules/express/lib/router/layer.js:95:5)
       at next (/sybase/central-js/node_modules/express/lib/router/route.js:131:13)
       at Route.dispatch (/sybase/central-js/node_modules/express/lib/router/route.js:112:3)
       at Layer.handle [as handle_request] (/sybase/central-js/node_modules/express/lib/router/layer.js:95:5)
       at /sybase/central-js/node_modules/express/lib/router/index.js:277:22
       at param (/sybase/central-js/node_modules/express/lib/router/index.js:349:14)
       at param (/sybase/central-js/node_modules/express/lib/router/index.js:365:14)
       at Function.process_params (/sybase/central-js/node_modules/express/lib/router/index.js:410:3) 