### PR TITLE
Default session config and livereload fix

### DIFF
--- a/dashboard-js/server/config/express.js
+++ b/dashboard-js/server/config/express.js
@@ -42,7 +42,7 @@ module.exports = function(app) {
   }
 
   if ('development' === env || 'test' === env) {
-    app.use(require('connect-livereload')());
+    app.use(require('connect-livereload')({port: 1337}));
     app.use(express.static(path.join(config.root, '.tmp')));
     app.use(express.static(path.join(config.root, 'client')));
     app.set('appPath', 'client');

--- a/dashboard-js/server/config/local.env.sample.js
+++ b/dashboard-js/server/config/local.env.sample.js
@@ -20,9 +20,9 @@ module.exports = {
   ACTIVITI_REST: 'wf/service',
   ACTIVITI_USER: 'activiti-master',
   ACTIVITI_PASSWORD: 'UjhtJnEvf!',
-  ACTIVITI_SESSION_IDLE: '3000',
-  ACTIVITI_SESSION_TIMEOUT: '3000',
-  ACTIVITI_SESSION_INTERVAL: '1000',
+  ACTIVITI_SESSION_IDLE: 3000,
+  ACTIVITI_SESSION_TIMEOUT: 3000,
+  ACTIVITI_SESSION_INTERVAL: 1000,
 
   PRIVATE_KEY: 'path to [sslcert/server.key]', //works only with SSL_PORT
   CERTIFICATE: 'path to [sslcert/server.crt]' //works only with SSL_PORT


### PR DESCRIPTION
Fixed

Error: Timeout must be zero or false to disable the feature, or a positive integer (in seconds) to enable it.
    at setTimeout.timeout (angular-idle.js:99)
    at startWatching (account.js:26)
    at account.js:68
    at Scope.$broadcast (angular.js:16311)
    at prepareRoute (angular-route.js:551)
    at Scope.$broadcast (angular.js:16311)
    at angular.js:12292
    at Scope.$eval (angular.js:15989)
    at Scope.$digest (angular.js:15800)
    at Scope.$apply (angular.js:16097)

and livereload port that was previously changed only in server part but not client one.