### PR TITLE
Виправлення помилок у Vagrant файлі

### DIFF
--- a/scripts/prepare_machine.sh
+++ b/scripts/prepare_machine.sh
@@ -44,7 +44,7 @@ then
     echo "already installed, skip"
 else
     TOMCAT_DIST=apache-tomcat-8.0.24.tar.gz
-    wget -nv -P $DOWNLOAD_DIR http://apache.cp.if.ua/tomcat/tomcat-8/v8.0.24/bin/$TOMCAT_DIST
+    wget -nv -P $DOWNLOAD_DIR https://archive.apache.org/dist/tomcat/tomcat-8/v8.0.24/bin/$TOMCAT_DIST
     tar -xvzf $DOWNLOAD_DIR/$TOMCAT_DIST -C $PROGRAMS_HOME
     rm $DOWNLOAD_DIR/$TOMCAT_DIST
     chown -R vagrant $TOMCAT_HOME
@@ -70,7 +70,7 @@ echo "******************************************************************"
 if ! dpkg --list nodejs | egrep -q ^ii; 
 then
     echo "add node js PPA  ..."
-    curl -sL https://deb.nodesource.com/setup | sudo bash -      
+    curl -sL https://deb.nodesource.com/setup_0.12 | sudo bash -
 fi
 
 apt-get install -y nodejs git g++ screen


### PR DESCRIPTION
- в пул-реквесті #649 виправлялась та ж сама помилка, у [репозиторії](https://www.apache.org/dist/tomcat/tomcat-8/) постійно змінюються версії tomcat і старі версії постійно видаляються, тому я змінив урл до файлу на постійний, який веде до архіву версії 8.0.24
- yeoman вимагає версію ноди не нижчу за 0.12, а встановлювалась 0.10. Змінив на 0.12