### PR TITLE
#1401, #1402, #1403, #1418

### DIFF
--- a/public-js/markers/Validator.js
+++ b/public-js/markers/Validator.js
@@ -1,0 +1,26 @@
+
+(function() {
+
+	var Validator = function () { 
+
+		// id of the field to validate 
+		this.fieldId = ""; 
+		// message that will be sent if validation empty 
+		this.message = ""; 
+
+		// type of the validator 
+		this.type = "clear"; 
+
+		this.validate = function () { 
+
+			return false; 
+		} 
+
+		return this; 
+	} 
+
+	var ValidationFactory = function ()  { 
+
+	} 
+
+})(); 

--- a/public-js/markers/defaults.js
+++ b/public-js/markers/defaults.js
@@ -125,7 +125,32 @@ angular.module('iGovMarkers')
       }
     },
     attributes: {
-      Editable_1: {aField_ID:['sPhone_User1', 'sMail_User1', 'bankIdlastName1'], bValue: true}
+      Editable_1: {aField_ID:['sPhone_User1', 'sMail_User1', 'bankIdlastName1'], bValue: true}, 
+      ExtendLabelStyle : {
+    	  aElement_IDs : ['textUa', 'vin_code'], 
+    	  aSelectors : ["col-sm-4"], 
+    	  sCondition : "",
+    	  // Загальний стиль для селекторів 
+    	  sCommonStyle : { "font-style" : "italic", "display" : "block" },
+    	  // Стиль для Central-js | = sCommonStyle 
+    	  sCentralStyle : { "font-style": "bold", "display": "block" }, 
+    	  // Стиль для Region  
+    	  sRegionStyle : { "font-style": "bold", "font-color": "#FF0000", "display": "block" }, 
+      }, 
+      
+      ExtendFormStyle : {
+    	  aElement_ID : ['testForm'],  	  
+    	  aSelector : ["test-form"], 
+    	  sCondition : "",
+    	  // Загальний стиль для селекторів 
+    	  sCommonStyle : { "font-style": "italic", "display": "block" },
+    	  // Стиль для Central-js | = sCommonStyle 
+    	  sCentralStyle : { "font-style": "bold", "display": "block" }, 
+    	  // Стиль для Region  
+    	  sRegionStyle : { "font-style": "bold", "font-color": "#FF0000", "display": "block" }, 
+
+      }
+      
     },
     motion: {
       ReplaceTextSymbols_1: {

--- a/public-js/markers/defaults.js
+++ b/public-js/markers/defaults.js
@@ -66,6 +66,28 @@ angular.module('iGovMarkers')
       ,CodeMFO: {
         aField_ID: ['mfo']
       }
+      ,StringRange: { 
+    	  aField_ID: ['string'],
+    	  aField_Type: ['string'], 
+    	  nMin: 0,
+    	  nMax: 200,
+    	  sMessage: 'Повинно бути від 0 до 200 символів'
+      }
+      ,LongNumber: {
+    	  aField_ID: ['long'],
+    	  aField_Type: ['long'],
+    	  nMin: 1,
+    	  nMax: 1000, 
+    	  sMessage: 'Повинно бути подільним числом від 1 до 1000 '
+      }
+      ,DoubleNumber: {
+    	  aField_ID: ['double'],
+    	  aField_Type: ['double'],
+    	  nMin: 1, 
+    	  nMax: 10000000,
+    	  sSeparator: '.',
+    	  sMessage: 'Повинно бути неподільним числом та розділене "."'
+      }
       ,NumberBetween: { //Целочисленное между
         aField_ID: ['numberBetween'],
         nMin: 1,

--- a/public-js/markers/field.attributes.service.js
+++ b/public-js/markers/field.attributes.service.js
@@ -8,6 +8,80 @@ function FieldAttributesService(MarkersFactory) {
     READ_ONLY: 2,
     NOT_SET: 3
   };
+  
+  // enables styles from the iGovMarkersDefaults -> attributes 
+  this.enableStyles = function () { 
+	  var selectors = iGovMarkersDefaults.attributes;
+
+	  if(selectors == null || selectors.length < 1 ) { 
+		  console.log( "FieldAttributesService iGovMarkersDefaults.attributes is not set" ); 
+		  return ;
+	  } 
+ 
+	  // цикл за селекторами iGovMarkersDefaults -> attributes  
+	  for ( var i = 0; i < selectors.length; i++ ) { 
+
+		  var styles = selectors[i];
+
+		  var commonStyle = {}; 
+		  var centralStyle = {}; 
+		  var regionStyle = {}; 
+
+		  // перевіряємо чи маємо, що встановлювати 
+		  if( styles.sCommonStyle != null && styles.sCommonStyle.length > 0 ) { 
+			  commonStyle = styles.sCommonStyle; 
+		  }
+		  
+		  if( styles.sCentralStyle != null && styles.sCommonStyle.length > 0 ) { 
+			  centralStyle = styles.sCentralStyle;  
+		  }
+		  else { // Встановлюємо загальний стиль  
+			  centralStyle = commonStyle; 
+		  }
+
+		  if( styles.sRegionStyle != null && styles.sRegionStyle.length > 0 ) { 
+			  regionStyle = styles.sRegionStyle; 
+		  } 
+		  else { // Встановлюємо загальний стиль  
+			  regionStyle = commonStyle; 
+		  }
+ 
+		  if( (commonStyle.length > 0 || centralStyle.length > 0 || regionStyle > 0) && styles.aElement_IDs != null && styles.aElement_IDs.length > 0 ) {
+			  
+			  for( var j = 0; j < styles.aElement_IDs.length; j++ ) {
+
+				  var elem = window.angular.element(document).find("#"+styles.aElement_IDs[j]);  
+				  elem.css(commonStyle);
+
+				  if ( StatesRepositoryProvider.isCentral() ) { 
+					  elem.css(centralStyle); 
+				  }
+				  else { 
+					  elem.css(regionStyle);
+				  }
+
+			  }
+
+		  }
+
+		  if( styles.aSelectors != null && styles.aSelectors.length > 0 ) { 
+
+			  for ( var j = 0; j < styles.aSelectors.length; j++ ) { 
+
+				  var elem = window.angular.element(document).find(styles.aSelectors[j]);
+				  elem.css(commonStyle); 
+				  
+				  if( StatesRepositoryProvider.isCentral() ) { 
+					  elem.css(centralStyle);
+				  }
+				  else { 
+					  elem.css(regionStyle);
+				  }
+			  }
+		  }
+		  
+	  }	  
+  }
 
   this.editableStatusFor = function(fieldId) {
     var result = self.EditableStatus.NOT_SET;

--- a/public-js/markers/schema.js
+++ b/public-js/markers/schema.js
@@ -261,6 +261,42 @@ angular.module('iGovMarkers')
                             required: ["aField_ID"],
                             additionalProperties: false
                         },
+                        "^StringRange": { 
+                        	type: "object",
+                        	properties: {
+                        		aField_ID: {"$ref": "#/definitions/stringArray"},
+                        		aField_Type: {"$ref": "#/definitions/stringArray"}, 
+                        		nMin: {type: "integer"},
+                        		nMax: {type: "integer"}, 
+                        		sMessage: {type: "string"}
+                        	},
+                        	required: ["aField_ID"],
+                        	additionalProperties: false
+                        },
+                        "^LongNumber": {
+                        	type: "object",
+                        	properties: {
+                        		aField_ID: {"$ref": "#/definitions/stringArray"},
+                        		aField_Type: {"$ref": "#/definitions/stringArray"}, 
+                        		nMin: {type: "integer"},
+                        		nMax: {type: "integer"},
+                        		sMessage: {type: "string"}
+                        	},
+                        	required: ["aField_ID"],
+                        	additionalProperties: false
+                        },
+                        "^DoubleNumber": { 
+                        	type: "object", 
+                        	properties: {
+                        		aField_ID: {"$ref": "#/definitions/stringArray"},
+                        		aField_Type: {"$ref": "#/definitions/stringArray"}, 
+                        		nMin: {type: "integer"}, 
+                        		nMax: {type: "integer"},
+                        		sMessage: {type: "string"}                     		
+                        	}, 
+                        	required: ["aField_ID"], 
+                        	additionalProperties: false
+                        }, 
                         "^NumberBetween": {
                             type: "object",
                             properties: {


### PR DESCRIPTION
Fixed #1401, #1402, #1403 
Functionality to support field.type = [ 'long' | 'double' | 'string' ] created 

Changes: 
- added new functions LongNumber, DoubleNumber, StringRange to ValidationService.validatorFunctionsByFieldId (line: 636-714)
- added new lines to ValidationService.validatorNameByMarkerName (line: 221)
- added new check for field.type in marker.aField_Type fieldTypeIsListedInMarker (lines: 131, 135, 170, 193)
- added new object ValidationService.validatorNameByType with new types long, double, string (lines: 227)
- added new defaults to iGovMarkersDefaults.validate (lines: 68-90)
- added new schema iGovMarkersSchema.validate (lines: 264-298)

Notice: in theory it is possible to attach existing markers to validation by field.type if add the section aField_Type: [ 'long' | 'tel' | 'double' ... ] 
Example: 
TextUA: {
        aField_Type: ['textUa'], 
} 
This allow to attach TextUa validation for field.type = 'textUA' 

Fixed #1418 

- added format to iGovMarkersDefaults -> attributes 
- added new method enableStyles to FieldsAttributesService (lines: 12-84) 
    that allows load custom styles from iGovMarkersDefaults and apply the styles to selectors 
